### PR TITLE
Fixed the link to start an app on the bushido page.

### DIFF
--- a/app/views/pages/support/installation/bushido.liquid
+++ b/app/views/pages/support/installation/bushido.liquid
@@ -4,7 +4,7 @@
 
 <p><a href="http://bushi.do">Bushido</a> is Locomotive's official hosting platform. Get Locomotive up and running instantly with Bushido - no forms or fields, just Locomotive.
   
-  <a href=href='http://bushi.do/apps/new?envs=&#123;"BUSHIDO_METRICS_TOKEN": "3c247258174b97e8ba60d19835def5cd"&#125;&repo=https://github.com/locomotivecms/engine.git' title='host now'>Launch Locomotive Now!</a></p>
+  <a href='http://bushi.do/apps/new?envs={"BUSHIDO_METRICS_TOKEN": "3c247258174b97e8ba60d19835def5cd"}&repo=https://github.com/locomotivecms/engine.git' title='host now'>Launch Locomotive Now!</a></p>
 
 <p>Focus on what makes you different - your design and content. Let Bushido handle the rest!</p>
 


### PR DESCRIPTION
The launch locomotive now link on this page http://www.locomotivecms.com/support/installation/bushido isn't working, http is written twice in the anchor tag. I've coped the link from the front page.
